### PR TITLE
Fix completion percentage displayed as speed

### DIFF
--- a/Languages/English/Keyed/PF_Keys.xml
+++ b/Languages/English/Keyed/PF_Keys.xml
@@ -54,7 +54,7 @@
 	<PF_RunningCountRuined> ({0} ruined)</PF_RunningCountRuined>
 
 	<PF_RunningInfo>Running ({0} complete)</PF_RunningInfo>
-	<PF_RunningSlow>Running slowly: {0} speed ({0} complete)</PF_RunningSlow>
+	<PF_RunningSlow>Running slowly: {0} speed ({1} complete)</PF_RunningSlow>
   <PF_NonIdealInfluences>Non-ideal {0}</PF_NonIdealInfluences>
 	<PF_NonIdealSpeedFactor>Speed: {0}</PF_NonIdealSpeedFactor>
 	<PF_IdealSafeProductionTemperature>Ideal (safe) production temp</PF_IdealSafeProductionTemperature>

--- a/Source/ProcessorFramework/CompProcessor.cs
+++ b/Source/ProcessorFramework/CompProcessor.cs
@@ -648,7 +648,7 @@ namespace ProcessorFramework
                 else if (activeProcesses[0].Ruined)
                     str.AppendTagged("PF_Ruined".Translate());
                 else if (activeProcesses[0].SpeedFactor < 0.75f)
-                    str.AppendTagged("PF_RunningSlow".Translate(activeProcesses[0].SpeedFactor.ToStringPercent(), activeProcesses[0].ActiveProcessPercent));
+                    str.AppendTagged("PF_RunningSlow".Translate(activeProcesses[0].SpeedFactor.ToStringPercent(), activeProcesses[0].ActiveProcessPercent.ToStringPercent()));
                 else
                     str.AppendTagged("PF_RunningInfo".Translate(activeProcesses[0].ActiveProcessPercent.ToStringPercent()));
             }


### PR DESCRIPTION
Previously, it displayed the speed percentage twice in RunningSlow, e.g. "Running slowly: 50% speed (50% complete). Now the second number will properly be displayed as the completion percentage.